### PR TITLE
fix(db) properly serialize maps in C* strategy

### DIFF
--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -272,7 +272,7 @@ local function serialize_arg(field, arg)
     local t = {}
 
     for k, v in pairs(arg) do
-      t[k] = serialize_arg(field.elements, arg[k])
+      t[k] = serialize_arg(field.values, arg[k])
     end
 
     serialized_arg = cassandra.map(t)


### PR DESCRIPTION
A map does not have `elements`, but `keys` and `values`.

This unfortunately does not come with a test, as no core entity has a
map field as of today.

Thanks @gszr for the report!

From #4383

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
